### PR TITLE
Generic FastaReader

### DIFF
--- a/src/fasta/writer.rs
+++ b/src/fasta/writer.rs
@@ -213,6 +213,10 @@ impl<W: std::io::Write, R: std::io::Read + std::io::Seek> Writer<W, R> {
         }
     }
 
+    pub fn inner_mut(&mut self) -> &mut BufWriter<W> {
+        &mut self.inner
+    }
+
     /// Writes the sequence of all exons, split by exon and feature (5' UTR, CDS, 3' UTR)
     ///
     /// The start coordinate is 0-based (as with bed files).

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -1,7 +1,6 @@
 use core::str::FromStr;
 use std::convert::TryFrom;
 use std::fmt;
-use std::fs::File;
 
 use crate::fasta::FastaReader;
 use crate::models::transcript::CoordinateVector;
@@ -387,11 +386,14 @@ impl Sequence {
     /// let seq = Sequence::from_coordinates(&coordinates, &Strand::Plus, &mut fasta_reader).unwrap();
     /// assert_eq!(seq.len(), 11);
     /// ```
-    pub fn from_coordinates(
+    pub fn from_coordinates<R>(
         coordinates: &CoordinateVector,
         strand: &crate::models::Strand,
-        fasta_reader: &mut FastaReader<File>,
-    ) -> Result<Sequence, FastaError> {
+        fasta_reader: &mut FastaReader<R>,
+    ) -> Result<Sequence, FastaError>
+    where
+        R: std::io::Seek + std::io::Read,
+    {
         let capacity: u32 = coordinates.iter().map(|x| x.2 - x.1 + 1).sum();
         let mut seq = Sequence::with_capacity(capacity as usize);
 

--- a/src/qc/mod.rs
+++ b/src/qc/mod.rs
@@ -73,8 +73,6 @@
 
 mod writer;
 
-use std::fs::File;
-
 use crate::fasta::FastaReader;
 use crate::models::{CoordinateVector, GeneticCode, Sequence, Transcript};
 use crate::utils::errors::FastaError;
@@ -206,7 +204,7 @@ impl QcCheck {
     /// let qc = QcCheck::new(&tx, &mut fasta_reader, &code);
     /// assert_eq!(qc.correct_start_codon(), QcResult::OK)
     /// ```
-    pub fn new(transcript: &Transcript, fasta: &mut FastaReader<File>, code: &GeneticCode) -> Self {
+    pub fn new(transcript: &Transcript, fasta: &mut FastaReader<impl std::io::Read + std::io::Seek>, code: &GeneticCode) -> Self {
         let mut res = QcCheck::default();
 
         let seq = match Sequence::from_coordinates(
@@ -291,7 +289,7 @@ impl QcCheck {
         &mut self,
         transcript: &Transcript,
         utr: CoordinateVector,
-        fasta: &mut FastaReader<File>,
+        fasta: &mut FastaReader<impl std::io::Read + std::io::Seek>,
     ) {
         match Sequence::from_coordinates(&utr, &transcript.strand(), fasta) {
             Ok(seq) => {
@@ -354,7 +352,7 @@ pub fn correct_cds_length(transcript: &Transcript) -> Option<bool> {
 /// IO errors or invalid coordinates of the transcript
 pub fn correct_start_codon(
     transcript: &Transcript,
-    fasta: &mut FastaReader<File>,
+    fasta: &mut FastaReader<impl std::io::Read + std::io::Seek>,
 ) -> Result<Option<bool>, FastaError> {
     let coords = transcript.start_codon();
 
@@ -392,7 +390,7 @@ pub fn correct_start_codon(
 /// IO errors or invalid coordinates of the transcript
 pub fn correct_stop_codon(
     transcript: &Transcript,
-    fasta: &mut FastaReader<File>,
+    fasta: &mut FastaReader<impl std::io::Read + std::io::Seek>,
     code: &GeneticCode,
 ) -> Result<Option<bool>, FastaError> {
     let coords = transcript.stop_codon();
@@ -431,7 +429,7 @@ pub fn correct_stop_codon(
 /// IO errors or invalid coordinates of the transcript
 pub fn no_upstream_stop_codon(
     transcript: &Transcript,
-    fasta: &mut FastaReader<File>,
+    fasta: &mut FastaReader<impl std::io::Read + std::io::Seek>,
     code: &GeneticCode,
 ) -> Result<Option<bool>, FastaError> {
     if !transcript.is_coding() {
@@ -459,7 +457,7 @@ pub fn no_upstream_stop_codon(
 /// does not indicate that the transcript is incorrect.
 pub fn no_upstream_start_codon(
     transcript: &Transcript,
-    fasta: &mut FastaReader<File>,
+    fasta: &mut FastaReader<impl std::io::Read + std::io::Seek>,
 ) -> Result<Option<bool>, FastaError> {
     if !transcript.is_coding() {
         return Ok(None);
@@ -483,7 +481,7 @@ pub fn no_upstream_start_codon(
 /// does not indicate that the transcript is incorrect.
 pub fn no_start_codon(
     transcript: &Transcript,
-    fasta: &mut FastaReader<File>,
+    fasta: &mut FastaReader<impl std::io::Read + std::io::Seek>,
 ) -> Result<bool, FastaError> {
     let seq =
         Sequence::from_coordinates(&transcript.exon_coordinates(), &transcript.strand(), fasta)?;


### PR DESCRIPTION
`FastaReader` can now use any `Read + Seek` implementer as an internal reader. The old version only allowed `File` based readers, but now clients can use more abstract readers, e.g. via HTTP or directly from an S3 bucket using [S3Reader](https://crates.io/crates/s3reader). 
Relates to #7 