### PR TITLE
Fix GTF parsing to allow 'gene' lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ criterion = "0.4"
 [[bench]]
 name = "genepred"
 harness = false
+
+[[bench]]
+name = "gtf"
+harness = false

--- a/benches/genepred.rs
+++ b/benches/genepred.rs
@@ -1,21 +1,16 @@
-use std::{fs::read_to_string};
+use std::fs::read_to_string;
 
 use atglib::models::TranscriptRead;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-
 use atglib::genepredext;
 
-
 fn read_from_bytes(data: &[u8]) {
-    let transcripts = genepredext::Reader::new(data)
-        .transcripts()
-        .unwrap();
-    assert_eq!(transcripts.len(), 1);    
+    let transcripts = genepredext::Reader::new(data).transcripts().unwrap();
+    assert_eq!(transcripts.len(), 1);
 }
 
 fn read_genepred_bench(c: &mut Criterion) {
-
     c.bench_function("NM_001365057.2", |b| {
         let data = read_to_string("tests/data/NM_001365057.2.genepredext").unwrap();
         b.iter(|| read_from_bytes(black_box(data.as_bytes())))
@@ -37,8 +32,5 @@ fn read_genepred_bench(c: &mut Criterion) {
     });
 }
 
-criterion_group!(
-    genepred,
-    read_genepred_bench,
-);
+criterion_group!(genepred, read_genepred_bench,);
 criterion_main!(genepred);

--- a/benches/gtf.rs
+++ b/benches/gtf.rs
@@ -1,0 +1,21 @@
+use std::fs::read_to_string;
+
+use atglib::models::TranscriptRead;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use atglib::gtf;
+
+fn read_from_bytes(data: &[u8]) {
+    let transcripts = gtf::Reader::new(data).transcripts().unwrap();
+    assert!(!transcripts.is_empty());
+}
+
+fn read_gtf_bench(c: &mut Criterion) {
+    c.bench_function("parse example GTF", |b| {
+        let data = read_to_string("tests/data/example.gtf").unwrap();
+        b.iter(|| read_from_bytes(black_box(data.as_bytes())))
+    });
+}
+
+criterion_group!(gtf, read_gtf_bench,);
+criterion_main!(gtf);

--- a/src/fasta/writer.rs
+++ b/src/fasta/writer.rs
@@ -205,7 +205,7 @@ impl<W: std::io::Write, R: std::io::Read + std::io::Seek> Writer<W, R> {
         }
     }
 
-    /// Unwraps this Writer<W>, returning the underlying writer.
+    /// Unwraps this `Writer<W>`, returning the underlying writer.
     pub fn into_inner(self) -> Result<W, ReadWriteError> {
         match self.inner.into_inner() {
             Ok(res) => Ok(res),

--- a/src/gtf/reader.rs
+++ b/src/gtf/reader.rs
@@ -209,15 +209,15 @@ mod test_nm_001385228 {
         let stop = t.stop_codon();
         assert_eq!(stop.len(), 2);
 
-        assert_eq!(t.exons()[0].is_coding(), false);
-        assert_eq!(t.exons()[1].is_coding(), false);
-        assert_eq!(t.exons()[2].is_coding(), false);
-        assert_eq!(t.exons()[3].is_coding(), false);
-        assert_eq!(t.exons()[4].is_coding(), false);
-        assert_eq!(t.exons()[5].is_coding(), true);
-        assert_eq!(t.exons()[6].is_coding(), true);
-        assert_eq!(t.exons()[7].is_coding(), true);
-        assert_eq!(t.exons()[8].is_coding(), false);
+        assert!(!t.exons()[0].is_coding());
+        assert!(!t.exons()[1].is_coding());
+        assert!(!t.exons()[2].is_coding());
+        assert!(!t.exons()[3].is_coding());
+        assert!(!t.exons()[4].is_coding());
+        assert!(t.exons()[5].is_coding());
+        assert!(t.exons()[6].is_coding());
+        assert!(t.exons()[7].is_coding());
+        assert!(!t.exons()[8].is_coding());
 
         assert_eq!(t.exons()[5].cds_start().unwrap(), 206105119);
         assert_eq!(t.exons()[6].cds_start().unwrap(), 206105123);
@@ -253,7 +253,7 @@ mod test_nm_201550 {
         let stop = t.stop_codon();
         assert_eq!(stop.len(), 1);
 
-        assert_eq!(t.exons()[0].is_coding(), true);
+        assert!(t.exons()[0].is_coding());
     }
 }
 
@@ -320,11 +320,11 @@ mod test_ighm {
         let stop = t.stop_codon();
         assert_eq!(stop.len(), 1);
 
-        assert_eq!(t.exons()[0].is_coding(), true);
-        assert_eq!(t.exons()[1].is_coding(), true);
-        assert_eq!(t.exons()[2].is_coding(), true);
-        assert_eq!(t.exons()[3].is_coding(), true);
-        assert_eq!(t.exons()[4].is_coding(), true);
+        assert!(t.exons()[0].is_coding());
+        assert!(t.exons()[1].is_coding());
+        assert!(t.exons()[2].is_coding());
+        assert!(t.exons()[3].is_coding());
+        assert!(t.exons()[4].is_coding());
 
         assert_eq!(t.cds_start_codon_stat(), CdsStat::Complete);
         assert_eq!(t.cds_stop_codon_stat(), CdsStat::Incomplete);

--- a/src/gtf/reader.rs
+++ b/src/gtf/reader.rs
@@ -465,4 +465,65 @@ mod tests {
             .is_err());
         assert!(reader.line().is_none());
     }
+
+    #[test]
+    fn test_5_utr() {
+        let transcript = "chr16\tncbiRefSeq.2021-05-17\t5UTR\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
+        let mut reader = Reader::new(transcript);
+        assert_eq!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .expect("The data is correct")
+            .feature(),
+            &GtfFeature::UTR5
+        );
+
+        let transcript = "chr16\tncbiRefSeq.2021-05-17\tfive_prime_utr\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
+        let mut reader = Reader::new(transcript);
+        assert_eq!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .expect("The data is correct")
+            .feature(),
+            &GtfFeature::UTR5
+        );
+    }
+
+    #[test]
+    fn test_3_utr() {
+        let transcript = "chr16\tncbiRefSeq.2021-05-17\t3UTR\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
+        let mut reader = Reader::new(transcript);
+        assert_eq!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .expect("The data is correct")
+            .feature(),
+            &GtfFeature::UTR3
+        );
+
+        let transcript = "chr16\tncbiRefSeq.2021-05-17\tthree_prime_utr\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
+        let mut reader = Reader::new(transcript);
+        assert_eq!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .expect("The data is correct")
+            .feature(),
+            &GtfFeature::UTR3
+        );
+    }
+
+    #[test]
+    fn test_utr() {
+        let transcript = "chr16\tncbiRefSeq.2021-05-17\tUTR\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
+        let mut reader = Reader::new(transcript);
+        assert_eq!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .expect("The data is correct")
+            .feature(),
+            &GtfFeature::UTR
+        );
+
+    }
+
 }

--- a/src/gtf/reader.rs
+++ b/src/gtf/reader.rs
@@ -421,7 +421,10 @@ mod tests {
         let transcript = "chr16\tncbiRefSeq.2021-05-17\tgene\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";\n\
         chr1\tncbiRefSeq.2021-05-17\texon\t206100298\t206100445\t.\t-\t.\tgene_id \"SRGAP2B\"; transcript_id \"NM_001385228.1_2\"; exon_number \"9\"; exon_id \"NM_001385228.1_2.9\"; gene_name \"SRGAP2B\";".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert!(reader.line().expect("The record contains one proper line").is_ok());
+        assert!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .is_ok());
         assert!(reader.line().is_none());
     }
 
@@ -429,7 +432,10 @@ mod tests {
     fn test_gene_line_contains_invalid_data() {
         let transcript = "chr16\tncbiRefSeq.2021-05-17\tgene\t66969419\t66978999\t.\tINVALID\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";\n".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert!(reader.line().expect("The record contains one proper line").is_err());
+        assert!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .is_err());
         assert!(reader.line().is_none());
     }
 
@@ -437,17 +443,26 @@ mod tests {
     fn test_without_gene_or_transcript_errors() {
         let transcript = "chr16\tncbiRefSeq.2021-05-17\texon\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";\n".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert!(reader.line().expect("The record contains one proper line").is_ok());
+        assert!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .is_ok());
         assert!(reader.line().is_none());
 
         let transcript = "chr16\tncbiRefSeq.2021-05-17\texon\t66969419\t66978999\t.\t+\t.\ttranscript_id \"NM_001365408.1\"; gene_name \"CES2\";\n".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert!(reader.line().expect("The record contains one proper line").is_err());
+        assert!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .is_err());
         assert!(reader.line().is_none());
 
         let transcript = "chr16\tncbiRefSeq.2021-05-17\texon\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; gene_name \"CES2\";\n".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert!(reader.line().expect("The record contains one proper line").is_err());
+        assert!(reader
+            .line()
+            .expect("The record contains one proper line")
+            .is_err());
         assert!(reader.line().is_none());
     }
 }

--- a/src/gtf/reader.rs
+++ b/src/gtf/reader.rs
@@ -470,21 +470,23 @@ mod tests {
     fn test_5_utr() {
         let transcript = "chr16\tncbiRefSeq.2021-05-17\t5UTR\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert_eq!(reader
-            .line()
-            .expect("The record contains one proper line")
-            .expect("The data is correct")
-            .feature(),
+        assert_eq!(
+            reader
+                .line()
+                .expect("The record contains one proper line")
+                .expect("The data is correct")
+                .feature(),
             &GtfFeature::UTR5
         );
 
         let transcript = "chr16\tncbiRefSeq.2021-05-17\tfive_prime_utr\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert_eq!(reader
-            .line()
-            .expect("The record contains one proper line")
-            .expect("The data is correct")
-            .feature(),
+        assert_eq!(
+            reader
+                .line()
+                .expect("The record contains one proper line")
+                .expect("The data is correct")
+                .feature(),
             &GtfFeature::UTR5
         );
     }
@@ -493,21 +495,23 @@ mod tests {
     fn test_3_utr() {
         let transcript = "chr16\tncbiRefSeq.2021-05-17\t3UTR\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert_eq!(reader
-            .line()
-            .expect("The record contains one proper line")
-            .expect("The data is correct")
-            .feature(),
+        assert_eq!(
+            reader
+                .line()
+                .expect("The record contains one proper line")
+                .expect("The data is correct")
+                .feature(),
             &GtfFeature::UTR3
         );
 
         let transcript = "chr16\tncbiRefSeq.2021-05-17\tthree_prime_utr\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert_eq!(reader
-            .line()
-            .expect("The record contains one proper line")
-            .expect("The data is correct")
-            .feature(),
+        assert_eq!(
+            reader
+                .line()
+                .expect("The record contains one proper line")
+                .expect("The data is correct")
+                .feature(),
             &GtfFeature::UTR3
         );
     }
@@ -516,14 +520,13 @@ mod tests {
     fn test_utr() {
         let transcript = "chr16\tncbiRefSeq.2021-05-17\tUTR\t66969419\t66978999\t.\t+\t.\tgene_id \"CES2\"; transcript_id \"NM_001365408.1\"; gene_name \"CES2\";".as_bytes();
         let mut reader = Reader::new(transcript);
-        assert_eq!(reader
-            .line()
-            .expect("The record contains one proper line")
-            .expect("The data is correct")
-            .feature(),
+        assert_eq!(
+            reader
+                .line()
+                .expect("The record contains one proper line")
+                .expect("The data is correct")
+                .feature(),
             &GtfFeature::UTR
         );
-
     }
-
 }

--- a/src/gtf/reader.rs
+++ b/src/gtf/reader.rs
@@ -209,15 +209,15 @@ mod test_nm_001385228 {
         let stop = t.stop_codon();
         assert_eq!(stop.len(), 2);
 
-        assert!(!t.exons()[0].is_coding());
-        assert!(!t.exons()[1].is_coding());
-        assert!(!t.exons()[2].is_coding());
-        assert!(!t.exons()[3].is_coding());
-        assert!(!t.exons()[4].is_coding());
-        assert!(t.exons()[5].is_coding());
-        assert!(t.exons()[6].is_coding());
-        assert!(t.exons()[7].is_coding());
-        assert!(!t.exons()[8].is_coding());
+        assert_eq!(t.exons()[0].is_coding(), false);
+        assert_eq!(t.exons()[1].is_coding(), false);
+        assert_eq!(t.exons()[2].is_coding(), false);
+        assert_eq!(t.exons()[3].is_coding(), false);
+        assert_eq!(t.exons()[4].is_coding(), false);
+        assert_eq!(t.exons()[5].is_coding(), true);
+        assert_eq!(t.exons()[6].is_coding(), true);
+        assert_eq!(t.exons()[7].is_coding(), true);
+        assert_eq!(t.exons()[8].is_coding(), false);
 
         assert_eq!(t.exons()[5].cds_start().unwrap(), 206105119);
         assert_eq!(t.exons()[6].cds_start().unwrap(), 206105123);
@@ -253,7 +253,7 @@ mod test_nm_201550 {
         let stop = t.stop_codon();
         assert_eq!(stop.len(), 1);
 
-        assert!(t.exons()[0].is_coding());
+        assert_eq!(t.exons()[0].is_coding(), true);
     }
 }
 
@@ -320,11 +320,11 @@ mod test_ighm {
         let stop = t.stop_codon();
         assert_eq!(stop.len(), 1);
 
-        assert!(t.exons()[0].is_coding());
-        assert!(t.exons()[1].is_coding());
-        assert!(t.exons()[2].is_coding());
-        assert!(t.exons()[3].is_coding());
-        assert!(t.exons()[4].is_coding());
+        assert_eq!(t.exons()[0].is_coding(), true);
+        assert_eq!(t.exons()[1].is_coding(), true);
+        assert_eq!(t.exons()[2].is_coding(), true);
+        assert_eq!(t.exons()[3].is_coding(), true);
+        assert_eq!(t.exons()[4].is_coding(), true);
 
         assert_eq!(t.cds_start_codon_stat(), CdsStat::Complete);
         assert_eq!(t.cds_stop_codon_stat(), CdsStat::Incomplete);

--- a/src/gtf/record.rs
+++ b/src/gtf/record.rs
@@ -32,8 +32,8 @@ impl FromStr for GtfFeature {
             "CDS" => Ok(Self::CDS),
             "start_codon" => Ok(Self::StartCodon),
             "stop_codon" => Ok(Self::StopCodon),
-            "5UTR" => Ok(Self::UTR5),
-            "3UTR" => Ok(Self::UTR3),
+            "5UTR" | "five_prime_utr" => Ok(Self::UTR5),
+            "3UTR" | "three_prime_utr" => Ok(Self::UTR3),
             "UTR" => Ok(Self::UTR),
             "inter" => Ok(Self::Inter),
             "inter_CNS" => Ok(Self::InterCNS),
@@ -266,7 +266,7 @@ pub(crate) struct UncheckedGtfRecord(GtfRecord);
 impl UncheckedGtfRecord {
     /// The feature type of the record is a standard feature, as described in the [GTF spec](crate::gtf)
     ///
-    /// "CDS", "start_codon", "stop_codon", "5UTR", "3UTR", "inter", "inter_CNS", "intron_CNS", "exon"
+    /// "CDS", "start_codon", "stop_codon", "5UTR", "3UTR", "UTR", "inter", "inter_CNS", "intron_CNS", "exon"
     pub fn standard_feature(&self) -> bool {
         matches!(
             self.0.feature,
@@ -276,6 +276,7 @@ impl UncheckedGtfRecord {
                 | GtfFeature::StopCodon
                 | GtfFeature::UTR5
                 | GtfFeature::UTR3
+                | GtfFeature::UTR
                 | GtfFeature::Inter
                 | GtfFeature::InterCNS
                 | GtfFeature::IntronCNS

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn test_create_sequence() {
         let s = "ATCGACGATCGATCGATGAGCGATCGACGATCGCGCTATCGCTA";
-        let seq = Sequence::from_str(&s).unwrap();
+        let seq = Sequence::from_str(s).unwrap();
 
         assert_eq!(seq.len(), 44);
         assert_eq!(seq.to_string(), s.to_string())
@@ -728,7 +728,7 @@ mod tests {
     #[test]
     fn test_chunks() {
         let s = "ATCGACGATCGATCGATGAGCGATCGACGATCGCGCTATCGCTA";
-        let seq = Sequence::from_str(&s).unwrap();
+        let seq = Sequence::from_str(s).unwrap();
 
         let mut iter = seq.chunks(3);
         assert_eq!(
@@ -744,33 +744,27 @@ mod tests {
     #[test]
     fn test_contains() {
         let s = "ATGCGA";
-        let seq = Sequence::from_str(&s).unwrap();
+        let seq = Sequence::from_str(s).unwrap();
 
-        assert_eq!(seq.contains(vec![Nucleotide::A]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::C]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::G]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::T]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::N]), false);
-        assert_eq!(seq.contains(vec![Nucleotide::A, Nucleotide::T]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::T, Nucleotide::G]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::A, Nucleotide::C]), false);
-        assert_eq!(seq.contains(vec![Nucleotide::G, Nucleotide::T]), false);
-        assert_eq!(seq.contains(vec![Nucleotide::G, Nucleotide::A]), true);
-        assert_eq!(
-            seq.contains(vec![Nucleotide::C, Nucleotide::G, Nucleotide::A]),
-            true
-        );
-        assert_eq!(
-            seq.contains(vec![Nucleotide::G, Nucleotide::A, Nucleotide::C]),
-            false
-        );
+        assert!(seq.contains(vec![Nucleotide::A]));
+        assert!(seq.contains(vec![Nucleotide::C]));
+        assert!(seq.contains(vec![Nucleotide::G]));
+        assert!(seq.contains(vec![Nucleotide::T]));
+        assert!(!seq.contains(vec![Nucleotide::N]));
+        assert!(seq.contains(vec![Nucleotide::A, Nucleotide::T]));
+        assert!(seq.contains(vec![Nucleotide::T, Nucleotide::G]));
+        assert!(seq.contains(vec![Nucleotide::A, Nucleotide::C]));
+        assert!(seq.contains(vec![Nucleotide::G, Nucleotide::T]));
+        assert!(seq.contains(vec![Nucleotide::G, Nucleotide::A]));
+        assert!(seq.contains(vec![Nucleotide::C, Nucleotide::G, Nucleotide::A]));
+        assert!(seq.contains(vec![Nucleotide::G, Nucleotide::A, Nucleotide::C]));
     }
 
     #[test]
     #[should_panic]
     fn test_contains_fails() {
         let s = "ATGCGA";
-        let seq = Sequence::from_str(&s).unwrap();
-        assert_eq!(seq.contains(vec![]), true);
+        let seq = Sequence::from_str(s).unwrap();
+        assert!(seq.contains(vec![]));
     }
 }

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn test_create_sequence() {
         let s = "ATCGACGATCGATCGATGAGCGATCGACGATCGCGCTATCGCTA";
-        let seq = Sequence::from_str(s).unwrap();
+        let seq = Sequence::from_str(&s).unwrap();
 
         assert_eq!(seq.len(), 44);
         assert_eq!(seq.to_string(), s.to_string())
@@ -728,7 +728,7 @@ mod tests {
     #[test]
     fn test_chunks() {
         let s = "ATCGACGATCGATCGATGAGCGATCGACGATCGCGCTATCGCTA";
-        let seq = Sequence::from_str(s).unwrap();
+        let seq = Sequence::from_str(&s).unwrap();
 
         let mut iter = seq.chunks(3);
         assert_eq!(
@@ -744,27 +744,33 @@ mod tests {
     #[test]
     fn test_contains() {
         let s = "ATGCGA";
-        let seq = Sequence::from_str(s).unwrap();
+        let seq = Sequence::from_str(&s).unwrap();
 
-        assert!(seq.contains(vec![Nucleotide::A]));
-        assert!(seq.contains(vec![Nucleotide::C]));
-        assert!(seq.contains(vec![Nucleotide::G]));
-        assert!(seq.contains(vec![Nucleotide::T]));
-        assert!(!seq.contains(vec![Nucleotide::N]));
-        assert!(seq.contains(vec![Nucleotide::A, Nucleotide::T]));
-        assert!(seq.contains(vec![Nucleotide::T, Nucleotide::G]));
-        assert!(seq.contains(vec![Nucleotide::A, Nucleotide::C]));
-        assert!(seq.contains(vec![Nucleotide::G, Nucleotide::T]));
-        assert!(seq.contains(vec![Nucleotide::G, Nucleotide::A]));
-        assert!(seq.contains(vec![Nucleotide::C, Nucleotide::G, Nucleotide::A]));
-        assert!(seq.contains(vec![Nucleotide::G, Nucleotide::A, Nucleotide::C]));
+        assert_eq!(seq.contains(vec![Nucleotide::A]), true);
+        assert_eq!(seq.contains(vec![Nucleotide::C]), true);
+        assert_eq!(seq.contains(vec![Nucleotide::G]), true);
+        assert_eq!(seq.contains(vec![Nucleotide::T]), true);
+        assert_eq!(seq.contains(vec![Nucleotide::N]), false);
+        assert_eq!(seq.contains(vec![Nucleotide::A, Nucleotide::T]), true);
+        assert_eq!(seq.contains(vec![Nucleotide::T, Nucleotide::G]), true);
+        assert_eq!(seq.contains(vec![Nucleotide::A, Nucleotide::C]), false);
+        assert_eq!(seq.contains(vec![Nucleotide::G, Nucleotide::T]), false);
+        assert_eq!(seq.contains(vec![Nucleotide::G, Nucleotide::A]), true);
+        assert_eq!(
+            seq.contains(vec![Nucleotide::C, Nucleotide::G, Nucleotide::A]),
+            true
+        );
+        assert_eq!(
+            seq.contains(vec![Nucleotide::G, Nucleotide::A, Nucleotide::C]),
+            false
+        );
     }
 
     #[test]
     #[should_panic]
     fn test_contains_fails() {
         let s = "ATGCGA";
-        let seq = Sequence::from_str(s).unwrap();
-        assert!(seq.contains(vec![]));
+        let seq = Sequence::from_str(&s).unwrap();
+        assert_eq!(seq.contains(vec![]), true);
     }
 }

--- a/src/models/sequence.rs
+++ b/src/models/sequence.rs
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn test_create_sequence() {
         let s = "ATCGACGATCGATCGATGAGCGATCGACGATCGCGCTATCGCTA";
-        let seq = Sequence::from_str(&s).unwrap();
+        let seq = Sequence::from_str(s).unwrap();
 
         assert_eq!(seq.len(), 44);
         assert_eq!(seq.to_string(), s.to_string())
@@ -728,7 +728,7 @@ mod tests {
     #[test]
     fn test_chunks() {
         let s = "ATCGACGATCGATCGATGAGCGATCGACGATCGCGCTATCGCTA";
-        let seq = Sequence::from_str(&s).unwrap();
+        let seq = Sequence::from_str(s).unwrap();
 
         let mut iter = seq.chunks(3);
         assert_eq!(
@@ -744,33 +744,27 @@ mod tests {
     #[test]
     fn test_contains() {
         let s = "ATGCGA";
-        let seq = Sequence::from_str(&s).unwrap();
+        let seq = Sequence::from_str(s).unwrap();
 
-        assert_eq!(seq.contains(vec![Nucleotide::A]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::C]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::G]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::T]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::N]), false);
-        assert_eq!(seq.contains(vec![Nucleotide::A, Nucleotide::T]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::T, Nucleotide::G]), true);
-        assert_eq!(seq.contains(vec![Nucleotide::A, Nucleotide::C]), false);
-        assert_eq!(seq.contains(vec![Nucleotide::G, Nucleotide::T]), false);
-        assert_eq!(seq.contains(vec![Nucleotide::G, Nucleotide::A]), true);
-        assert_eq!(
-            seq.contains(vec![Nucleotide::C, Nucleotide::G, Nucleotide::A]),
-            true
-        );
-        assert_eq!(
-            seq.contains(vec![Nucleotide::G, Nucleotide::A, Nucleotide::C]),
-            false
-        );
+        assert!(seq.contains(vec![Nucleotide::A]));
+        assert!(seq.contains(vec![Nucleotide::C]));
+        assert!(seq.contains(vec![Nucleotide::G]));
+        assert!(seq.contains(vec![Nucleotide::T]));
+        assert!(!seq.contains(vec![Nucleotide::N]));
+        assert!(seq.contains(vec![Nucleotide::A, Nucleotide::T]));
+        assert!(seq.contains(vec![Nucleotide::T, Nucleotide::G]));
+        assert!(!seq.contains(vec![Nucleotide::A, Nucleotide::C]));
+        assert!(!seq.contains(vec![Nucleotide::G, Nucleotide::T]));
+        assert!(seq.contains(vec![Nucleotide::G, Nucleotide::A]));
+        assert!(seq.contains(vec![Nucleotide::C, Nucleotide::G, Nucleotide::A]));
+        assert!(!seq.contains(vec![Nucleotide::G, Nucleotide::A, Nucleotide::C]));
     }
 
     #[test]
     #[should_panic]
     fn test_contains_fails() {
         let s = "ATGCGA";
-        let seq = Sequence::from_str(&s).unwrap();
-        assert_eq!(seq.contains(vec![]), true);
+        let seq = Sequence::from_str(s).unwrap();
+        assert!(seq.contains(vec![]));
     }
 }

--- a/src/qc/mod.rs
+++ b/src/qc/mod.rs
@@ -538,108 +538,134 @@ mod test {
 
     #[test]
     fn test_starts_with_start_codon() {
-        assert!(starts_with_start_codon(
-            &Sequence::from_str("ATGCGATGAT").unwrap()
-        ));
-        assert!(starts_with_start_codon(&Sequence::from_str("ATG").unwrap()));
-        assert!(starts_with_start_codon(&Sequence::from_str("AT").unwrap()));
-        assert!(starts_with_start_codon(&Sequence::from_str("TG").unwrap()));
-        assert!(starts_with_start_codon(&Sequence::from_str("").unwrap()));
-        assert!(starts_with_start_codon(
-            &Sequence::from_str("CATG").unwrap()
-        ));
+        assert_eq!(
+            starts_with_start_codon(&Sequence::from_str("ATGCGATGAT").unwrap()),
+            true
+        );
+        assert_eq!(
+            starts_with_start_codon(&Sequence::from_str("ATG").unwrap()),
+            true
+        );
+        assert_eq!(
+            starts_with_start_codon(&Sequence::from_str("AT").unwrap()),
+            false
+        );
+        assert_eq!(
+            starts_with_start_codon(&Sequence::from_str("TG").unwrap()),
+            false
+        );
+        assert_eq!(
+            starts_with_start_codon(&Sequence::from_str("").unwrap()),
+            false
+        );
+        assert_eq!(
+            starts_with_start_codon(&Sequence::from_str("CATG").unwrap()),
+            false
+        );
     }
 
     #[test]
     fn test_extra_start_codon() {
-        assert!(extra_start_codon(&Sequence::from_str("ATGCGACGA").unwrap()));
-        assert!(extra_start_codon(&Sequence::from_str("ATG").unwrap()));
-        assert!(extra_start_codon(&Sequence::from_str("AT").unwrap()));
-        assert!(extra_start_codon(&Sequence::from_str("TG").unwrap()));
-        assert!(extra_start_codon(&Sequence::from_str("").unwrap()));
-        assert!(extra_start_codon(&Sequence::from_str("CATG").unwrap()));
-        assert!(extra_start_codon(&Sequence::from_str("CAATG").unwrap()));
+        assert_eq!(
+            extra_start_codon(&Sequence::from_str("ATGCGACGA").unwrap()),
+            true
+        );
+        assert_eq!(extra_start_codon(&Sequence::from_str("ATG").unwrap()), true);
+        assert_eq!(extra_start_codon(&Sequence::from_str("AT").unwrap()), false);
+        assert_eq!(extra_start_codon(&Sequence::from_str("TG").unwrap()), false);
+        assert_eq!(extra_start_codon(&Sequence::from_str("").unwrap()), false);
+        assert_eq!(
+            extra_start_codon(&Sequence::from_str("CATG").unwrap()),
+            true
+        );
+        assert_eq!(
+            extra_start_codon(&Sequence::from_str("CAATG").unwrap()),
+            true
+        );
     }
 
     #[test]
     fn test_check_inframe_stop() {
         let code = GeneticCode::default();
-        assert!(early_stop_codon(
-            &Sequence::from_str("TAGAAA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(&Sequence::from_str("TAG").unwrap(), &code));
-        assert!(early_stop_codon(
-            &Sequence::from_str("TAGT").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("TAGTA").unwrap(),
-            &code
-        ));
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("TAGAAA").unwrap(), &code),
+            true
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("TAG").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("TAGT").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("TAGTA").unwrap(), &code),
+            false
+        );
 
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATGCGATAGTTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATGCGATAATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATGCGATGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("TAGATGCGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("TAAATGCGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("TGAATGCGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATGCGATAG").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATGCGATAA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATGCGATGA").unwrap(),
-            &code
-        ));
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATGCGATAGTTA").unwrap(), &code),
+            true
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATGCGATAATTA").unwrap(), &code),
+            true
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATGCGATGATTA").unwrap(), &code),
+            true
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("TAGATGCGATTA").unwrap(), &code),
+            true
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("TAAATGCGATTA").unwrap(), &code),
+            true
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("TGAATGCGATTA").unwrap(), &code),
+            true
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATGCGATAG").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATGCGATAA").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATGCGATGA").unwrap(), &code),
+            false
+        );
 
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATAGATGCGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATAAATGCGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATGAATGCGATTA").unwrap(),
-            &code
-        ));
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATAGATGCGATTA").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATAAATGCGATTA").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATGAATGCGATTA").unwrap(), &code),
+            false
+        );
 
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATTAGATGCGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATTAAATGCGATTA").unwrap(),
-            &code
-        ));
-        assert!(early_stop_codon(
-            &Sequence::from_str("ATTGAATGCGATTA").unwrap(),
-            &code
-        ));
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATTAGATGCGATTA").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATTAAATGCGATTA").unwrap(), &code),
+            false
+        );
+        assert_eq!(
+            early_stop_codon(&Sequence::from_str("ATTGAATGCGATTA").unwrap(), &code),
+            false
+        );
     }
 
     #[test]

--- a/src/qc/mod.rs
+++ b/src/qc/mod.rs
@@ -538,134 +538,108 @@ mod test {
 
     #[test]
     fn test_starts_with_start_codon() {
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("ATGCGATGAT").unwrap()),
-            true
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("ATG").unwrap()),
-            true
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("AT").unwrap()),
-            false
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("TG").unwrap()),
-            false
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("").unwrap()),
-            false
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("CATG").unwrap()),
-            false
-        );
+        assert!(starts_with_start_codon(
+            &Sequence::from_str("ATGCGATGAT").unwrap()
+        ));
+        assert!(starts_with_start_codon(&Sequence::from_str("ATG").unwrap()));
+        assert!(starts_with_start_codon(&Sequence::from_str("AT").unwrap()));
+        assert!(starts_with_start_codon(&Sequence::from_str("TG").unwrap()));
+        assert!(starts_with_start_codon(&Sequence::from_str("").unwrap()));
+        assert!(starts_with_start_codon(
+            &Sequence::from_str("CATG").unwrap()
+        ));
     }
 
     #[test]
     fn test_extra_start_codon() {
-        assert_eq!(
-            extra_start_codon(&Sequence::from_str("ATGCGACGA").unwrap()),
-            true
-        );
-        assert_eq!(extra_start_codon(&Sequence::from_str("ATG").unwrap()), true);
-        assert_eq!(extra_start_codon(&Sequence::from_str("AT").unwrap()), false);
-        assert_eq!(extra_start_codon(&Sequence::from_str("TG").unwrap()), false);
-        assert_eq!(extra_start_codon(&Sequence::from_str("").unwrap()), false);
-        assert_eq!(
-            extra_start_codon(&Sequence::from_str("CATG").unwrap()),
-            true
-        );
-        assert_eq!(
-            extra_start_codon(&Sequence::from_str("CAATG").unwrap()),
-            true
-        );
+        assert!(extra_start_codon(&Sequence::from_str("ATGCGACGA").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("ATG").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("AT").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("TG").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("CATG").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("CAATG").unwrap()));
     }
 
     #[test]
     fn test_check_inframe_stop() {
         let code = GeneticCode::default();
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGAAA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAG").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGT").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGTA").unwrap(), &code),
-            false
-        );
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAGAAA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(&Sequence::from_str("TAG").unwrap(), &code));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAGT").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAGTA").unwrap(),
+            &code
+        ));
 
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAGTTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGATGCGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAAATGCGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TGAATGCGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAG").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATGA").unwrap(), &code),
-            false
-        );
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATAGTTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATAATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAGATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TGAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATAG").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATAA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATGA").unwrap(),
+            &code
+        ));
 
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATAGATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATAAATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGAATGCGATTA").unwrap(), &code),
-            false
-        );
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATAGATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATAAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGAATGCGATTA").unwrap(),
+            &code
+        ));
 
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATTAGATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATTAAATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATTGAATGCGATTA").unwrap(), &code),
-            false
-        );
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATTAGATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATTAAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATTGAATGCGATTA").unwrap(),
+            &code
+        ));
     }
 
     #[test]

--- a/src/qc/mod.rs
+++ b/src/qc/mod.rs
@@ -538,134 +538,111 @@ mod test {
 
     #[test]
     fn test_starts_with_start_codon() {
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("ATGCGATGAT").unwrap()),
-            true
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("ATG").unwrap()),
-            true
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("AT").unwrap()),
-            false
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("TG").unwrap()),
-            false
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("").unwrap()),
-            false
-        );
-        assert_eq!(
-            starts_with_start_codon(&Sequence::from_str("CATG").unwrap()),
-            false
-        );
+        assert!(starts_with_start_codon(
+            &Sequence::from_str("ATGCGATGAT").unwrap()
+        ));
+        assert!(starts_with_start_codon(&Sequence::from_str("ATG").unwrap()));
+        assert!(!starts_with_start_codon(&Sequence::from_str("AT").unwrap()));
+        assert!(!starts_with_start_codon(&Sequence::from_str("TG").unwrap()));
+        assert!(!starts_with_start_codon(&Sequence::from_str("").unwrap()));
+        assert!(!starts_with_start_codon(
+            &Sequence::from_str("CATG").unwrap()
+        ));
     }
 
     #[test]
     fn test_extra_start_codon() {
-        assert_eq!(
-            extra_start_codon(&Sequence::from_str("ATGCGACGA").unwrap()),
-            true
-        );
-        assert_eq!(extra_start_codon(&Sequence::from_str("ATG").unwrap()), true);
-        assert_eq!(extra_start_codon(&Sequence::from_str("AT").unwrap()), false);
-        assert_eq!(extra_start_codon(&Sequence::from_str("TG").unwrap()), false);
-        assert_eq!(extra_start_codon(&Sequence::from_str("").unwrap()), false);
-        assert_eq!(
-            extra_start_codon(&Sequence::from_str("CATG").unwrap()),
-            true
-        );
-        assert_eq!(
-            extra_start_codon(&Sequence::from_str("CAATG").unwrap()),
-            true
-        );
+        assert!(extra_start_codon(&Sequence::from_str("ATGCGACGA").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("ATG").unwrap()));
+        assert!(!extra_start_codon(&Sequence::from_str("AT").unwrap()));
+        assert!(!extra_start_codon(&Sequence::from_str("TG").unwrap()));
+        assert!(!extra_start_codon(&Sequence::from_str("").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("CATG").unwrap()));
+        assert!(extra_start_codon(&Sequence::from_str("CAATG").unwrap()));
     }
 
     #[test]
     fn test_check_inframe_stop() {
         let code = GeneticCode::default();
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGAAA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAG").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGT").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGTA").unwrap(), &code),
-            false
-        );
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAGAAA").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("TAG").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("TAGT").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("TAGTA").unwrap(),
+            &code
+        ));
 
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAGTTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAGATGCGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TAAATGCGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("TGAATGCGATTA").unwrap(), &code),
-            true
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAG").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATAA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGCGATGA").unwrap(), &code),
-            false
-        );
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATAGTTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATAATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("ATGCGATGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAGATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TAAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(early_stop_codon(
+            &Sequence::from_str("TGAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATGCGATAG").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATGCGATAA").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATGCGATGA").unwrap(),
+            &code
+        ));
 
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATAGATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATAAATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATGAATGCGATTA").unwrap(), &code),
-            false
-        );
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATAGATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATAAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATGAATGCGATTA").unwrap(),
+            &code
+        ));
 
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATTAGATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATTAAATGCGATTA").unwrap(), &code),
-            false
-        );
-        assert_eq!(
-            early_stop_codon(&Sequence::from_str("ATTGAATGCGATTA").unwrap(), &code),
-            false
-        );
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATTAGATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATTAAATGCGATTA").unwrap(),
+            &code
+        ));
+        assert!(!early_stop_codon(
+            &Sequence::from_str("ATTGAATGCGATTA").unwrap(),
+            &code
+        ));
     }
 
     #[test]

--- a/src/qc/writer.rs
+++ b/src/qc/writer.rs
@@ -172,7 +172,7 @@ impl<W: std::io::Write, R: std::io::Read + std::io::Seek> Writer<W, R> {
 
     /// Writes the header row for the tab-separated QC results
     pub fn write_header(&mut self) -> Result<(), std::io::Error> {
-        let columns = vec![
+        let columns = [
             "Gene",
             "transcript",
             "Exon",

--- a/src/refgene/reader.rs
+++ b/src/refgene/reader.rs
@@ -349,7 +349,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert!(exons.is_err());
+        assert_eq!(exons.is_err(), true);
         assert_eq!(
             exons.unwrap_err().message,
             "Too few exon ends in input".to_string()
@@ -378,7 +378,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert!(exons.is_err());
+        assert_eq!(exons.is_err(), true);
         assert_eq!(
             exons.unwrap_err().message,
             "Too few exon starts in input".to_string()
@@ -407,7 +407,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert!(exons.is_err());
+        assert_eq!(exons.is_err(), true);
         assert_eq!(
             exons.unwrap_err().message,
             "Too few exon Frame offsets".to_string()
@@ -436,7 +436,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert!(exons.is_err());
+        assert_eq!(exons.is_err(), true);
         assert_eq!(
             exons.unwrap_err().message,
             "invalid frame indicator /".to_string()

--- a/src/refgene/reader.rs
+++ b/src/refgene/reader.rs
@@ -349,7 +349,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert_eq!(exons.is_err(), true);
+        assert!(exons.is_err());
         assert_eq!(
             exons.unwrap_err().message,
             "Too few exon ends in input".to_string()
@@ -378,7 +378,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert_eq!(exons.is_err(), true);
+        assert!(exons.is_err());
         assert_eq!(
             exons.unwrap_err().message,
             "Too few exon starts in input".to_string()
@@ -407,7 +407,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert_eq!(exons.is_err(), true);
+        assert!(exons.is_err());
         assert_eq!(
             exons.unwrap_err().message,
             "Too few exon Frame offsets".to_string()
@@ -436,7 +436,7 @@ mod tests {
         ];
         let exons = instantiate_exons(&cols);
 
-        assert_eq!(exons.is_err(), true);
+        assert!(exons.is_err());
         assert_eq!(
             exons.unwrap_err().message,
             "invalid frame indicator /".to_string()

--- a/src/refgene/writer.rs
+++ b/src/refgene/writer.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as FmtWrite;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
@@ -137,23 +138,35 @@ impl From<&Transcript> for Vec<String> {
         // Don't ask, but some reason the refGene specs indicate that
         // there is also a trailing comma after the list of exons
         // e.g.: `12227,12721,14409,`
-        columns[EXON_STARTS_COL] = transcript
-            .exons()
-            .iter()
-            // RefGene handled start coordinates differently, so we substract 1.
-            // See the comments in `instantiate_exons`.
-            .map(|exon| format!("{},", (exon.start() - 1)))
-            .collect();
-        columns[EXON_ENDS_COL] = transcript
-            .exons()
-            .iter()
-            .map(|exon| format!("{},", exon.end()))
-            .collect();
-        columns[EXON_FRAMES_COL] = transcript
-            .exons()
-            .iter()
-            .map(|exon| format!("{},", exon.frame_offset().to_refgene()))
-            .collect();
+
+        columns[EXON_STARTS_COL] = transcript.exons().iter().fold(
+            // Assuming that most genomic positions are 8-9 digits, plus the comma
+            String::with_capacity(transcript.exon_count() * 10),
+            |mut output, exon| {
+                // RefGene handled start coordinates differently, so we substract 1.
+                // See the comments in `instantiate_exons`.
+                let _ = write!(output, "{},", exon.start() - 1);
+                output
+            },
+        );
+
+        columns[EXON_ENDS_COL] = transcript.exons().iter().fold(
+            // Assuming that most genomic positions are 8-9 digits, plus the comma
+            String::with_capacity(transcript.exon_count() * 10),
+            |mut output, exon| {
+                let _ = write!(output, "{},", exon.end());
+                output
+            },
+        );
+
+        columns[EXON_FRAMES_COL] = transcript.exons().iter().fold(
+            // Assuming that most genomic positions are 8-9 digits, plus the comma
+            String::with_capacity(transcript.exon_count() * 10),
+            |mut output, exon| {
+                let _ = write!(output, "{},", exon.frame_offset().to_refgene());
+                output
+            },
+        );
 
         columns
     }

--- a/src/spliceai/writer.rs
+++ b/src/spliceai/writer.rs
@@ -248,7 +248,7 @@ mod test_spliceailine {
             .write_transcript_vec(&transcripts)
             .expect("Error writing into bytevec");
         let written_output = String::from_utf8(writer.into_inner().unwrap()).unwrap();
-        let expected_output = [
+        let expected_output = vec![
             "Test-Gene",
             "chr1",
             "+",
@@ -303,7 +303,7 @@ mod test_spliceailine {
             .write_transcripts(&transcripts)
             .expect("Error writing into bytevec");
         let written_output = String::from_utf8(writer.into_inner().unwrap()).unwrap();
-        let expected_output1 = [
+        let expected_output1 = vec![
             "Test-Gene",
             "chr1",
             "+",
@@ -314,7 +314,7 @@ mod test_spliceailine {
         ]
         .join("\t")
         .to_string();
-        let expected_output2 = [
+        let expected_output2 = vec![
             "Test-Gene_2",
             "chr1",
             "+",

--- a/src/spliceai/writer.rs
+++ b/src/spliceai/writer.rs
@@ -248,7 +248,7 @@ mod test_spliceailine {
             .write_transcript_vec(&transcripts)
             .expect("Error writing into bytevec");
         let written_output = String::from_utf8(writer.into_inner().unwrap()).unwrap();
-        let expected_output = vec![
+        let expected_output = [
             "Test-Gene",
             "chr1",
             "+",
@@ -303,7 +303,7 @@ mod test_spliceailine {
             .write_transcripts(&transcripts)
             .expect("Error writing into bytevec");
         let written_output = String::from_utf8(writer.into_inner().unwrap()).unwrap();
-        let expected_output1 = vec![
+        let expected_output1 = [
             "Test-Gene",
             "chr1",
             "+",
@@ -314,7 +314,7 @@ mod test_spliceailine {
         ]
         .join("\t")
         .to_string();
-        let expected_output2 = vec![
+        let expected_output2 = [
             "Test-Gene_2",
             "chr1",
             "+",

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -101,7 +101,7 @@ impl fmt::Debug for ParseGtfError {
 
 impl From<BuildTranscriptError> for ParseGtfError {
     fn from(f: BuildTranscriptError) -> ParseGtfError {
-        ParseGtfError::new(&f.to_string())
+        ParseGtfError::new(f.to_string())
     }
 }
 
@@ -113,7 +113,7 @@ impl From<String> for ParseGtfError {
 
 impl From<ParseIntError> for ParseGtfError {
     fn from(e: ParseIntError) -> ParseGtfError {
-        ParseGtfError::new(&e.to_string())
+        ParseGtfError::new(e.to_string())
     }
 }
 


### PR DESCRIPTION
This addresses https://github.com/anergictcell/atg/issues/38

Some GTF files contain lines for a whole `gene`. These lines don't include the `transcript_id` attribute and so far caused atg to crash. The new version will now ignore those lines, as they are not relevant for the internal logic anyway